### PR TITLE
Fix PostToken

### DIFF
--- a/registry-server/src/main/java/com/registry/controller/oauth/OAuthController.java
+++ b/registry-server/src/main/java/com/registry/controller/oauth/OAuthController.java
@@ -97,24 +97,10 @@ public class OAuthController {
 
     @PostMapping(Path.OAUTH_TOKEN)
     @ApiOperation(value = "dummy token", notes = "dummy token API")
-    protected Object getDummyToken(
-            @ApiParam(
-                defaultValue = "Basic cmVnaXN0cnk6cmVnaXN0cnktc2VjcmV0",
-                value = "",
-                required = true) @RequestHeader(name = "Authorization") String authorization,
-           @ApiParam(
-                   defaultValue = "admin",
-                   value = "username",
-                   required = true
-           ) @RequestParam(name = "username") String username,
-           @ApiParam(
-                   defaultValue = "password",
-                   value = "password",
-                   required = true
-           ) @RequestParam(name = "password") String password ) throws Exception {
-
-        Map result = oAuthService.getToken(username, password);
-        return result;
+    @ResponseStatus(value = HttpStatus.NOT_FOUND, reason = "Resource Not Found")
+    protected Object postToken() throws Exception {
+        logger.info("dummy function for containerd");
+        return null;
     }
 
     @GetMapping(Path.OAUTH_TOKEN)


### PR DESCRIPTION
이미지 빌드-> 배포 후 테스트 결과

노드에서 crictl로 이미지 pull: 기존 400에서 401에러로 변환됨
```
# /usr/local/bin/crictl pull  skb-registry.taco/lma-admin/nginxtest
FATA[0000] pulling image: rpc error: code = Unknown desc = failed to pull and unpack image "skb-registry.taco/lma-admin/nginxtest:latest": failed to resolve reference "skb-registry.taco/lma-admin/nginxtest:latest": failed to authorize: failed to fetch oauth token: unexpected status: 401
```

taco-registry-app의 로그
```
 01:43:17.438 [http-nio-8080-exec-2] INFO  c.r.controller.oauth.OAuthController - dummy function for containerd
01:43:17.441 [http-nio-8080-exec-9] INFO  com.registry.service.OAuthService - getJWTToken username : lma.admin@example.com
01:43:17.441 [http-nio-8080-exec-9] INFO  com.registry.service.OAuthService - getJWTToken password : ehdwkrxkzh1!
01:43:17.441 [http-nio-8080-exec-9] INFO  com.registry.service.OAuthService - getJWTToken service : taco-registry
01:43:17.441 [http-nio-8080-exec-9] INFO  com.registry.service.OAuthService - getJWTToken scope : repository:lma-admin/nginxtest:pull
01:43:17.441 [http-nio-8080-exec-9] INFO  com.registry.service.UserService - getUser username : lma.admin@example.com
Hibernate:
    select
        user0_.username as username1_10_0_,
        user0_.created_by as created13_10_0_,
        user0_.created_date as created_2_10_0_,
        user0_.updated_by as updated14_10_0_,
        user0_.updated_date as updated_3_10_0_,
        user0_.del_yn as del_yn4_10_0_,
        user0_.email as email5_10_0_,
        user0_.enabled as enabled6_10_0_,
        user0_.minio_enabled as minio_en7_10_0_,
        user0_.minio_host as minio_ho8_10_0_,
        user0_.minio_port as minio_po9_10_0_,
        user0_.name as name10_10_0_,
        user0_.password as passwor11_10_0_,
        user0_.super_user as super_u12_10_0_
    from
        users user0_
    where
        user0_.username=?
01:43:17.444 [http-nio-8080-exec-9] ERROR com.registry.service.AbstractService - [API:/api/oauth/token] 401 UNAUTHORIZED unauthorized: [unauthorized], {}

```


그 이외에 이전에 없던 redis connection 에러가 계속 발생 (기존 이미지와 소스가 동일하지 않은 증거?)
```
01:43:21.244 [PollingServerListUpdater-0] WARN  c.n.l.PollingServerListUpdater - Failed one update cycle
org.springframework.data.redis.RedisConnectionFailureException: Cannot get Jedis connection; nested exception is redis.clients.jedis.exceptions.JedisConnectionException: Could not get a resource from the pool
        at org.springframework.data.redis.connection.jedis.JedisConnectionFactory.fetchJedisConnector(JedisConnectionFactory.java:281)
        at org.springframework.data.redis.connection.jedis.JedisConnectionFactory.getConnection(JedisConnectionFactory.java:464)
        at org.springframework.data.redis.core.RedisConnectionUtils.doGetConnection(RedisConnectionUtils.java:132)
        at org.springframework.data.redis.core.RedisConnectionUtils.bindConnection(RedisConnectionUtils.java:70)
        at org.springframework.data.redis.core.RedisTemplate.execute(RedisTemplate.java:209)
        at org.springframework.data.redis.core.RedisTemplate.execute(RedisTemplate.java:184)
        at org.springframework.data.redis.core.AbstractOperations.execute(AbstractOperations.java:95)
        at org.springframework.data.redis.core.DefaultValueOperations.get(DefaultValueOperations.java:53)
        at com.registry.config.RibbonServerList.getUpdatedListOfServers(RibbonServerList.java:34)
        at com.netflix.loadbalancer.DynamicServerListLoadBalancer.updateListOfServers(DynamicServerListLoadBalancer.java:240)
        at com.netflix.loadbalancer.DynamicServerListLoadBalancer$1.doUpdate(DynamicServerListLoadBalancer.java:62)
        at com.netflix.loadbalancer.PollingServerListUpdater$1.run(PollingServerListUpdater.java:116)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:750)
Caused by: redis.clients.jedis.exceptions.JedisConnectionException: Could not get a resource from the pool
        at redis.clients.util.Pool.getResource(Pool.java:53)
        at redis.clients.jedis.JedisPool.getResource(JedisPool.java:226)
        at redis.clients.jedis.JedisPool.getResource(JedisPool.java:16)
        at org.springframework.data.redis.connection.jedis.JedisConnectionFactory.fetchJedisConnector(JedisConnectionFactory.java:271)
        ... 18 common frames omitted
Caused by: redis.clients.jedis.exceptions.JedisConnectionException: Failed connecting to host taco-redis:6379
        at redis.clients.jedis.Connection.connect(Connection.java:207)
        at redis.clients.jedis.BinaryClient.connect(BinaryClient.java:101)
        at redis.clients.jedis.BinaryJedis.connect(BinaryJedis.java:1844)
        at redis.clients.jedis.JedisFactory.makeObject(JedisFactory.java:106)
        at org.apache.commons.pool2.impl.GenericObjectPool.create(GenericObjectPool.java:889)
        at org.apache.commons.pool2.impl.GenericObjectPool.borrowObject(GenericObjectPool.java:424)
        at org.apache.commons.pool2.impl.GenericObjectPool.borrowObject(GenericObjectPool.java:349)
        at redis.clients.util.Pool.getResource(Pool.java:49)
        ... 21 common frames omitted
Caused by: java.net.UnknownHostException: taco-redis
        at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:184)
        at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392)
        at java.net.Socket.connect(Socket.java:607)
        at redis.clients.jedis.Connection.connect(Connection.java:184)
        ... 28 common frames omitted
```